### PR TITLE
add link to smealum/3ds_hb_menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ To use the grid launcher as your homebrew menu, simply rename the 3dsx executabl
 
 Select the "?" icon in the top right corner of the launcher to view help pages. Press START in hbmenu to reboot your console into home menu. Use the D-PAD, CIRCLE-PAD or the touchscreen to select an application, and press A or touch it again to start it.
 
-#### Please see the README.md from the original launcher for more technical details
+#### Please see the [README.md from the original launcher](https://github.com/smealum/3ds_hb_menu) for more technical details


### PR DESCRIPTION
since this launcher is no longer classified as a "fork" by GitHub, a link back to the original is probably the best idea.